### PR TITLE
Import Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,106 @@
 # Code of Conduct
 
-Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.fb.com/codeofconduct/) so that you can understand what actions will and will not be tolerated.
+This code of conduct outlines our expectations for participants within
+the osquery community, as well as steps to reporting unacceptable
+behavior. We are committed to providing a welcoming and inspiring
+community for all and expect our code of conduct to be honored. Anyone
+who violates this code of conduct may be banned from the community.
+
+Our community strives to:
+
+* **Be friendly and patient.**
+* **Be welcoming**: We strive to be a community that welcomes and
+  supports people of all backgrounds and identities. This includes,
+  but is not limited to members of any race, ethnicity, culture,
+  national origin, color, immigration status, social and economic
+  class, educational level, sex, sexual orientation, gender identity
+  and expression, age, size, family status, political belief,
+  religion, and mental and physical ability.
+* **Be considerate**: Your work will be used by other people, and you
+in turn will depend on the work of others. Any decision you take will
+affect users and colleagues, and you should take those consequences
+into account when making decisions. Remember that we’re a world-wide
+community, so you might not be communicating in someone else’s primary
+language.  Be respectful: Not all of us will agree all the time, but
+disagreement is no excuse for poor behavior and poor manners. We might
+all experience some frustration now and then, but we cannot allow that
+frustration to turn into a personal attack. It’s important to remember
+that a community where people feel uncomfortable or threatened is not
+a productive one.
+* **Be careful in the words that you choose**: we are a community of
+  professionals, and we conduct ourselves professionally. Be kind to
+  others. Do not insult or put down other participants. Harassment and
+  other exclusionary behavior aren’t acceptable. This includes, but is
+  not limited to:
+  - Violent threats or language directed against another person.
+  - Discriminatory jokes and language.
+  - Posting sexually explicit or violent material.
+  - Posting (or threatening to post) other people’s personally identifying information (“doxing”).
+  - Personal insults, especially those using racist or sexist terms.
+  - Unwelcome sexual attention.
+  - Advocating for, or encouraging, any of the above behavior.
+  - Repeated harassment of others. In general, if someone asks you to stop, then stop.
+  - **When we disagree, try to understand why**: Disagreements, both
+    social and technical, happen all the time. It is important that we
+    resolve disagreements and differing views constructively.
+  - **Remember that we’re different.** The strength of our community
+    comes from its diversity, people from a wide range of
+    backgrounds. Different people have different perspectives on
+    issues. Being unable to understand why someone holds a viewpoint
+    doesn’t mean that they’re wrong. Don’t forget that it is human to
+    err and blaming each other doesn’t get us anywhere. Instead, focus
+    on helping to resolve issues and learning from mistakes.
+
+This code is not exhaustive or complete. It serves to distill our
+common understanding of a collaborative, shared environment, and
+goals. We expect it to be followed in spirit as much as in the letter.
+
+## Diversity Statement
+
+We encourage everyone to participate and are committed to building a
+community for all. Although we may not be able to satisfy everyone, we
+all agree that everyone is equal. Whenever a participant has made a
+mistake, we expect them to take responsibility for it. If someone has
+been harmed or offended, it is our responsibility to listen carefully
+and respectfully, and do our best to right the wrong.
+
+Although this list cannot be exhaustive, we explicitly honor diversity
+in age, gender, gender identity or expression, culture, ethnicity,
+language, national origin, political beliefs, profession, race,
+religion, sexual orientation, socioeconomic status, and technical
+ability. We will not tolerate discrimination based on any of the
+protected characteristics above, including participants with
+disabilities.
+
+## Reporting Issues
+
+If you experience or witness unacceptable behavior—or have any other
+concerns—please report it by contacting us via osquery@osquery.io. All
+reports will be handled with discretion. In your report please
+include:
+
+* Your contact information.
+* Names (real, nicknames, or pseudonyms) of any individuals
+  involved. If there are additional witnesses, please include them as
+  well. Your account of what occurred, and if you believe the incident
+  is ongoing. If there is a publicly available record (e.g. a mailing
+  list archive or a public IRC logger), please include a link.
+* Any additional information that may be helpful.
+
+After filing a report, a representative will contact you
+personally. If the person who is harassing you is part of the response
+team, they will recuse themselves from handling your incident. A
+representative will then review the incident, follow up with any
+additional questions, and make a decision as to how to respond. We
+will respect confidentiality requests for the purpose of protecting
+victims of abuse.
+
+Anyone asked to stop unacceptable behavior is expected to comply
+immediately. If an individual engages in unacceptable behavior, the
+representative may take any action they deem appropriate, up to and
+including a permanent ban from our community without warning.
+
+This Code Of Conduct follows the
+[template](http://todogroup.org/opencodeofconduct/) established by the
+[TODO Group](http://todogroup.org/).
+


### PR DESCRIPTION
This is a straight import of the code of conduct at https://engineering.fb.com/codeofconduct/

It's been manually reformatted into markdown, and the references to Facebook have been changed to osquery.